### PR TITLE
Update to last crystal version

### DIFF
--- a/src/fast-http-server.cr
+++ b/src/fast-http-server.cr
@@ -10,6 +10,14 @@ class FastHttpServer < HTTP::StaticFileHandler
     super
   end
 
+  def port=(value)
+    3000
+  end
+
+  def port
+    @port
+  end
+
   def call(context)
     if context.request.path.not_nil! == "/"
       index_path = Dir.current + "/index.html"


### PR DESCRIPTION
I have a compilation error on last release (even **master**)

``` crystal
Error in ./src/fast-http-server.cr:25: instantiating 'OptionParser:Class#parse!()'
  OptionParser.parse! do |opts|
               ^~~~~~
in /opt/crystal/src/option_parser.cr:56: instantiating 'parse(Array(String))'
    parse(ARGV) { |parser| yield parser }
    ^~~~~
in /opt/crystal/src/option_parser.cr:56: instantiating 'parse(Array(String))'
    parse(ARGV) { |parser| yield parser }
    ^~~~~
in ./src/fast-http-server.cr:25: instantiating 'OptionParser:Class#parse!()'
  OptionParser.parse! do |opts|
               ^~~~~~
in ./src/fast-http-server.cr:30: instantiating 'FastHttpServer#port=(String)'
      FastHttpServer::INSTANCE.port = port
                               ^~~~
in macro 'property' /opt/crystal/src/object.cr:672, line 7:
  1.     
  2.       
  3.         def port
  4.           @port
  5.         end
  6. 
  7.         def port=(@port)
  8.         end
  9.       
 10.     
 11.   
        def port=(@port)
                  ^~~~~
instance variable '@port' of FastHttpServer must be Int32, not String
```
